### PR TITLE
Add http prefix to ip

### DIFF
--- a/components/cmd/README.md
+++ b/components/cmd/README.md
@@ -1,1 +1,26 @@
 # AID Command Line Utility
+
+to get started making adding features:  
+   
+
+1. make a local build
+
+```
+cd components/cmd 
+make ci-build
+```
+
+2. run commands using the new local build
+examples:
+```
+./aid --help
+```
+or
+```
+./aid up
+```
+3. make changes and rebuild the relevant component, for example for the cli
+
+```
+make build-cli
+```

--- a/components/cmd/internal/daemon/server.go
+++ b/components/cmd/internal/daemon/server.go
@@ -39,7 +39,7 @@ func printIpAddress(port string) {
 			case *net.IPNet:
 				ip = v.IP.String()
 				if strings.Count(ip, ":") < 2 {
-					fmt.Println("\t IP Address: " + ip + ":" + port)
+					fmt.Println("\t IP Address: " + "http://" + ip + ":" + port)
 				}
 			case *net.IPAddr:
 			}


### PR DESCRIPTION
reference issue #1854 

the ip address printed when running `aid up` should now be clickable in most terminals.

![image](https://user-images.githubusercontent.com/45671832/143594155-f7ad318c-4b2e-4178-b0c2-3a04b9108def.png)

also added some instructions to cmd/README.md with how to build locally